### PR TITLE
remove the input for the parameter multi

### DIFF
--- a/proto_md/system.py
+++ b/proto_md/system.py
@@ -574,7 +574,7 @@ class System(object):
             top=top,
             top_includes=self.top_includes,
             nsteps=self.config[MD_STEPS],
-            multi=self.config[MULTI],
+            #multi=self.config[MULTI],
             deffnm="md",
             mainselection=self.mainselection,
             **md_args


### PR DESCRIPTION
Turning line 577 in `system.py` to a comment to avoid adding `-multi` as a flag for `grompp `